### PR TITLE
Remove duplicate return statements

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -24,5 +24,3 @@ def search_text(q: str = Query(..., min_length=2), top_k: int = 20):
 def ingest_url(url: str):
     job_id = tasks.ingest_from_url.delay(url).id
     return {"job_id": job_id}
-    return {"job_id": job_id}
-    return {"job_id": job_id}


### PR DESCRIPTION
## Summary
- clean ingest_url endpoint by removing redundant return statements

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be2496e09c8324bca2641a908dc0ac