### PR TITLE
Remove stubbed search code and duplicates

### DIFF
--- a/backend/api/search.py
+++ b/backend/api/search.py
@@ -1,47 +1,4 @@
 
-"""Search indexing and query stubs."""
-
-import os
-from typing import List, Dict
-
-
-def index_transcript(media_id: str, transcript: List[Dict]) -> None:
-    """Index a transcript into the search backends.
-
-    This function is currently a placeholder. In a real implementation the
-    segments would be sent to OpenSearch/Qdrant for hybrid search.
-
-    Args:
-        media_id: Unique identifier for the media.
-        transcript: List of segment dictionaries produced by Whisper/WhisperX.
-    """
-
-    # TODO: Implement OpenSearch/Qdrant indexing logic here.
-    _ = (media_id, transcript)  # pragma: no cover - placeholder
-
-
-def hybrid_search(query: str, k: int = 20) -> Dict[str, List[Dict]]:
-    """Perform a hybrid search over indexed transcripts.
-
-    Args:
-        query: Text to search for.
-        k: Number of results to return.
-
-    Returns:
-        A stubbed response mimicking the structure of a real search result.
-    """
-
-    # TODO: connect to OpenSearch/Qdrant and return real results
-    return {
-        "query": query,
-        "results": [
-            {
-                "media_id": "demo",
-                "t0": 12.34,
-                "t1": 18.9,
-                "text": "Example snippet matching: " + query,
-            }
-        ][:k],
 """Search utilities for the OpenWords backend.
 
 This module provides a :func:`hybrid_search` function which performs a text
@@ -177,16 +134,3 @@ def hybrid_search(query: str, k: int = 20) -> Dict[str, Any]:
     merged = sorted(os_hits + qd_hits, key=lambda r: r.get("score", 0.0), reverse=True)
 
     return {"query": query, "results": merged[:k]}
-
-import os
-
-def hybrid_search(query: str, k: int = 20):
-    # TODO: connect to OpenSearch/Qdrant and return real results
-    # For now, return a stubbed response structure.
-    return {
-        "query": query,
-        "results": [
-            {"media_id": "demo", "t0": 12.34, "t1": 18.9, "text": "Example snippet matching: " + query}
-        ][:k]
-    }
-    }


### PR DESCRIPTION
## Summary
- drop obsolete search stubs and duplicate `hybrid_search`
- keep single implementation that merges OpenSearch and Qdrant results

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be249a2d0c83249a0093765389f4a7