### PR TITLE
Remove stubbed ingestion task

### DIFF
--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -119,15 +119,3 @@ def ingest_from_url(self, url: str) -> Dict[str, str]:
             os.rmdir(temp_dir)
         except OSError:
             pass
-
-import os, uuid
-from celery import Celery
-
-celery = Celery(__name__, broker=os.environ.get("REDIS_URL", "redis://redis:6379/0"))
-
-@celery.task
-def ingest_from_url(url: str):
-    # TODO: download with yt-dlp, transcribe (Whisper/WhisperX), index into search
-    media_id = str(uuid.uuid4())
-    return {"media_id": media_id, "url": url, "status": "stubbed"}
-    return {"media_id": media_id, "url": url, "status": "stubbed"}


### PR DESCRIPTION
## Summary
- remove duplicate imports and stubbed `ingest_from_url` task from `backend/api/tasks.py`
- retain fully implemented ingestion task

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be249b75b483248eb8fc58564309a3