### PR TITLE
Clean up duplicate services in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,6 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-    depends_on: [ db, opensearch, qdrant, minio, redis ]
     ports: [ "8000:8000" ]
   worker:
     image: python:3.11-slim
@@ -51,7 +50,6 @@ services:
         condition: service_healthy
       qdrant:
         condition: service_healthy
-    depends_on: [ api, redis ]
 
   web:
     image: node:20
@@ -97,14 +95,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-
-  minio:
-    image: minio/minio:RELEASE.2024-04-18T19-09-19Z
-
-  qdrant:
-    image: qdrant/qdrant:latest
-    ports: [ "6333:6333" ]
-
   minio:
     image: minio/minio:RELEASE.2024-04-18T19-09-19Z
     command: server /data --console-address ":9001"
@@ -128,7 +118,3 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-
-  redis:
-    image: redis:7
-    ports: [ "6379:6379" ]


### PR DESCRIPTION
## Summary
- remove duplicate depends_on blocks
- consolidate qdrant, minio, and redis services

## Testing
- ❌ `docker compose config` *(docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68be249cac388324ac0693dc82a2c59d